### PR TITLE
Temporarily Hardcode User Roles and Enabled Status During Authentication

### DIFF
--- a/src/main/java/com/example/mailsystem/config/SecurityConfig.java
+++ b/src/main/java/com/example/mailsystem/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.mailsystem.config;
 
+import javax.sql.DataSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.HttpMethod;
@@ -10,10 +11,12 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import javax.sql.DataSource;
 
 @EnableWebSecurity
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    private DataSource dataSource;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -32,14 +35,18 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .disable();
     }
 
-    @Autowired
-    private DataSource dataSource;
-
+    // Temporary Hardcoded Enable and Role for User Authentication:
+    // Due to the inherent behavior of Spring Security's jdbcAuthentication(), it requires 'enabled' and 'authority' details.
+    // Currently, our application does not have these specific fields in the 'user' table. Therefore, 
+    // as a temporary measure, 'true' is hardcoded as the 'enabled' status and 'ROLE_USER' as the 'authority' for all users.
+    // This ensures Spring Security can perform the authentication process without errors.
+    // Please note, this is a temporary fix and should be updated once we have implemented a more comprehensive role management system.
     @Override
     protected void configure(AuthenticationManagerBuilder auth) throws Exception {
         auth.jdbcAuthentication().dataSource(dataSource)
                 .passwordEncoder(passwordEncoder())
-                .usersByUsernameQuery("SELECT username, password FROM user WHERE username = ?");
+                .usersByUsernameQuery("SELECT username, password, 'true' as enabled FROM user WHERE username = ?")
+                .authoritiesByUsernameQuery("SELECT username, 'ROLE_USER' FROM user WHERE username = ?");
     }
 
     @Override

--- a/src/main/java/com/example/mailsystem/controller/AuthenticationController.java
+++ b/src/main/java/com/example/mailsystem/controller/AuthenticationController.java
@@ -3,11 +3,9 @@ package com.example.mailsystem.controller;
 import com.example.mailsystem.model.Token;
 import com.example.mailsystem.model.User;
 import com.example.mailsystem.service.AuthenticationService;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
 
 @RestController
 public class AuthenticationController {

--- a/src/main/java/com/example/mailsystem/service/AuthenticationService.java
+++ b/src/main/java/com/example/mailsystem/service/AuthenticationService.java
@@ -5,15 +5,13 @@ import com.example.mailsystem.model.Token;
 import com.example.mailsystem.model.User;
 import com.example.mailsystem.repository.UserRepository;
 import com.example.mailsystem.util.JwtUtil;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.authentication.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Service;
-
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 @Service
 public class AuthenticationService {
 
@@ -21,6 +19,7 @@ public class AuthenticationService {
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
 
+    private final Logger logger = LoggerFactory.getLogger(AuthenticationService.class);
 
     @Autowired
     public AuthenticationService(AuthenticationManager authenticationManager, JwtUtil jwtUtil, UserRepository userRepository) {
@@ -33,8 +32,16 @@ public class AuthenticationService {
         Authentication auth = null;
         try {
             auth = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(user.getUsername(),user.getPassword()));
+        } catch (BadCredentialsException exception) {
+            logger.error("BadCredentialsException: ", exception);
+            throw new BadCredentialsException("Bad Credentials");
         } catch (AuthenticationException exception) {
-            throw new UserNotExistException("User Doesn't Exist11");
+            logger.error("AuthenticationException: ", exception);
+            throw new AuthenticationException("Authentication Exception") {
+            };
+        } catch (Exception exception) {
+            logger.error("Exception: ", exception);
+            throw new UserNotExistException("Internal Server Error");
         }
 
         if( auth == null || !auth.isAuthenticated()) {


### PR DESCRIPTION
Temporarily Hardcode User Roles and Enabled Status During AuthenticationAdjusted the configuration of the AuthenticationManagerBuilder to fix an SQLSyntaxErrorException. The application was trying to query an 'authorities' table that doesn't exist. To circumvent this issue, a static 'ROLE_USER' role is now assigned to all users during authentication, eliminating the need to access the 'authorities' table. 

In addition to this, we're also assuming that all users are 'enabled' by default as our database currently doesn't store this attribute. 

Please note that these are temporary solutions and cater to the current need of the application. For more complex role management and enabling/disabling of users in the future, this code needs to be revised accordingly.
